### PR TITLE
Explicitly set fixversions to ""

### DIFF
--- a/backend/plugins/github/tasks/issue_convertor.go
+++ b/backend/plugins/github/tasks/issue_convertor.go
@@ -102,6 +102,7 @@ func ConvertIssues(taskCtx plugin.SubTaskContext) errors.Error {
 				ResolutionDate:  issue.ClosedAt,
 				Severity:        issue.Severity,
 				Component:       issue.Component,
+				FixVersions:     "", // GitHub issues don't have fix versions
 			}
 			if issue.AssigneeId != 0 {
 				domainIssue.AssigneeId = accountIdGen.Generate(data.Options.ConnectionId, issue.AssigneeId)


### PR DESCRIPTION
This pull request adds a clarification to the `ConvertIssues` function regarding GitHub issues. Specifically, it introduces a new field `FixVersions` with an empty string as its value, indicating that GitHub issues do not support fix versions.